### PR TITLE
perftrackerlib/helpers/httppool.py - GET requests now can have bodies…

### DIFF
--- a/perftrackerlib/helpers/httppool.py
+++ b/perftrackerlib/helpers/httppool.py
@@ -71,6 +71,12 @@ class HTTPConnectionPycurl:
                 c.unsetopt(pycurl.CUSTOMREQUEST)
                 c.setopt(pycurl.NOBODY, 0)
                 self.cleaning_needed = False
+            if body:
+                self.cleaning_needed = True
+                c.setopt(pycurl.POST, 0)
+                c.setopt(pycurl.CUSTOMREQUEST, verb)
+                c.setopt(pycurl.NOBODY, 0)
+                c.setopt(pycurl.POSTFIELDS, body or "")
         elif verb == 'POST':
             self.cleaning_needed = True
             c.unsetopt(pycurl.CUSTOMREQUEST)


### PR DESCRIPTION
… (required for ElasticSearch API)

