### PR TITLE
Rename Shell to ptShell

### DIFF
--- a/examples/pt_suite_example_ab.py
+++ b/examples/pt_suite_example_ab.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function, absolute_import
- 
+
 # -*- coding: utf-8 -*-
 __author__ = "perfguru87@gmail.com"
 __copyright__ = "Copyright 2018, The PerfTracker project"
@@ -26,6 +26,7 @@ reREQ = re.compile("Complete requests:\s+(\d+).*")
 EXIT_AB_ERROR = -1
 EXIT_URL_VALIDATION = -2
 EXIT_NO_URLS = -3
+
 
 class ABLauncher:
     def __init__(self, suite, urls, concurrencies=None, iterations=3, requests=0, time=5):
@@ -84,10 +85,9 @@ class ABLauncher:
 
     def init(self):
         self._validate_urls()
-
         self.suite.addNode(ptHost("client", ip='127.0.0.1', scan_info=True))
         self.suite.upload()
-	self.print_ab_header()
+        self.print_ab_header()
 
     def launch(self):
         for concurrency in self.concurrencies:
@@ -138,7 +138,7 @@ def main():
     if not urls:
         op.print_help()
         print("Example:\n    %s http://www.google.com/" % basename)
-        sys.exit(EXIT_NOR_URLS)
+        sys.exit(EXIT_NO_URLS)
 
     loglevel = logging.DEBUG if opts.verbose else logging.INFO
     logging.basicConfig(level=loglevel, format="%(asctime)s - %(module)s - %(levelname)s - %(message)s")
@@ -149,6 +149,7 @@ def main():
                     requests=opts.requests, iterations=opts.iterations, time=opts.time)
     ab.init()
     ab.launch()
+
 
 if __name__ == "__main__":
     main()

--- a/perftrackerlib/browser/cp_crawler.py
+++ b/perftrackerlib/browser/cp_crawler.py
@@ -53,7 +53,7 @@ from .page import PageStats, PageStatsSummary
 from .utils import gen_urls_from_index_file
 from .cp_engine import CPEngineBase
 from ..helpers.texttable import TextTable
-from ..helpers.shell import Shell
+from ..helpers.ptshell import ptShell
 from selenium.webdriver.remote.remote_connection import LOGGER as selenium_logger
 
 bindir, basename = os.path.split(sys.argv[0])
@@ -198,7 +198,7 @@ class CPBrowserRunner:
         if not self.opts.pt_title and product_name and product_ver:
             browser_name = self.browser.browser_get_name()
             browser_name += self.browser.browser_get_version().split(".")[0]
-            ghz = Shell().hw_info.cpu_freq_ghz
+            ghz = ptShell().hw_info.cpu_freq_ghz
             self.pt_suite.job_title = "%s %s @ %s %1.fGHz" % (product_name, product_ver, browser_name, ghz)
 
         ram = virtual_memory()

--- a/perftrackerlib/helpers/ptshell.py
+++ b/perftrackerlib/helpers/ptshell.py
@@ -228,7 +228,7 @@ class ptShellFromFile(citizenshell.abstractshell.AbstractShell):
         citizenshell.abstractshell.AbstractShell.__init__(self)
         self.from_file = from_file
 
-    def execute(self, command, **kwargs):
+    def execute(self, cmdline, raise_exc=True, **kwargs):
         class FakeResult:
             def __init__(self, output):
                 self.output = output.split('\n')
@@ -241,7 +241,7 @@ class ptShellFromFile(citizenshell.abstractshell.AbstractShell):
                     yield line
 
         with open(self.from_file) as output:
-            return 0, output.read(), ""
+            return 0, output.readlines(), ""
 
 
 ##############################################################################


### PR DESCRIPTION
pt_suite_example_ab.py - fix PEP8, typos
client.py - Rename Shell to ptShell, add ptShellFromFile, add eq method to ptTest
cp_crawler.py Refactor Shell imports
shell.py Renamed to ptshell.py